### PR TITLE
Fix package.json `main` for webpack

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-intl",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Provides API for using Native date, time and number formatting with an API similar to Intl.js",
     "main": "nativescript-intl",
     "nativescript": {

--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
     "name": "nativescript-intl",
     "version": "0.0.3",
     "description": "Provides API for using Native date, time and number formatting with an API similar to Intl.js",
-    "main": "nativescript-intl.js",
+    "main": "nativescript-intl",
     "nativescript": {
         "platforms": {
             "android": "2.1.0",


### PR DESCRIPTION
By chopping the '.js' suffix off to make webpack's `resolve.extensions: [".android.js"]` target the right file.

//cc @nsndeck 