### PR TITLE
Fix android number format

### DIFF
--- a/src/nativescript-intl.android.ts
+++ b/src/nativescript-intl.android.ts
@@ -161,7 +161,7 @@ export class NumberFormat extends commonNumberFormat {
             new java.text.DecimalFormatSymbols(getNativeLocale(locale)) :
             new java.text.DecimalFormatSymbols();
         
-        if (options.currency !== void 0) {
+        if (options && options.currency !== void 0) {
             decimalFormatSymbols.setCurrency(java.util.Currency.getInstance(options.currency));
         }
         

--- a/src/nativescript-intl.android.ts
+++ b/src/nativescript-intl.android.ts
@@ -160,6 +160,11 @@ export class NumberFormat extends commonNumberFormat {
         let decimalFormatSymbols = locale ?
             new java.text.DecimalFormatSymbols(getNativeLocale(locale)) :
             new java.text.DecimalFormatSymbols();
+        
+        if (options.currency !== void 0) {
+            decimalFormatSymbols.setCurrency(java.util.Currency.getInstance(options.currency));
+        }
+        
         numberFormat.setDecimalFormatSymbols(decimalFormatSymbols);
 
         if (options && (options.style.toLowerCase() === "currency" && options.currencyDisplay === "code")) {
@@ -169,10 +174,6 @@ export class NumberFormat extends commonNumberFormat {
                 currrentPattern = currrentPattern.replace("¤", "¤¤");
                 numberFormat = new java.text.DecimalFormat(currrentPattern);
                 numberFormat.setDecimalFormatSymbols(decimalFormatSymbols);
-            }
-
-            if (options.currency !== void 0) {
-                decimalFormatSymbols.setCurrency(java.util.Currency.getInstance(options.currency));
             }
         }
 


### PR DESCRIPTION
It seems that the currency should be set on the DecimalFormatSymbols instance before setting it to the NumberFormat instance in order to display proper currency.

With the old implementation, we had the following results, from which the first is ok, but the second is wrong:
```js
const bgFormat = new Intl.NumberFormat('bg-BG', {
	style: 'currency',
	currency: 'BGN',
});
const usFormat = new Intl.NumberFormat('en-US', {
	style: 'currency',
	currency: 'BGN',
});
console.log(bgFormat.format(123.9)); // 123,90 лв.
console.log(usFormat.format(123.9)); // $123.90
```

And with the new one, the second call results in `BGN123.90` which seems to be the correct result.

Fixes #23 