### PR TITLE
fix: Index for leading delimiters can get out of bounds if conditions are true for all elements

### DIFF
--- a/src/nativescript-intl-common.ts
+++ b/src/nativescript-intl-common.ts
@@ -184,7 +184,7 @@ export class DateTimeFormat implements intlDateTimeFormat {
         let result = [];
         let i = 0;
         // remove leading delimiters
-        while (patternOptions[i].patternValue === "" || patternOptions[i].isDateElement === false) { i++; }
+        while (i < patternOptionsLength && (patternOptions[i].patternValue === "" || patternOptions[i].isDateElement === false)) { i++; }
         for (i; i < patternOptionsLength; i++) {
             result.push(patternOptions[i].patternValue);
         }

--- a/src/nativescript-intl-common.ts
+++ b/src/nativescript-intl-common.ts
@@ -184,7 +184,7 @@ export class DateTimeFormat implements intlDateTimeFormat {
         let result = [];
         let i = 0;
         // remove leading delimiters
-        while (i < patternOptionsLength && (patternOptions[i].patternValue === "" || patternOptions[i].isDateElement === false)) { i++; }
+        while (patternOptions[i] && (patternOptions[i].patternValue === "" || patternOptions[i].isDateElement === false)) { i++; }
         for (i; i < patternOptionsLength; i++) {
             result.push(patternOptions[i].patternValue);
         }


### PR DESCRIPTION
The while loop for leading delimiters is quite dangerous, as it can lead to index being out of bounds.
We should make sure index increment does not exceed array length.